### PR TITLE
Correctly limit the number of theory test cases

### DIFF
--- a/samples/BasicSample/TheoriesHaveTheirLimits.cs
+++ b/samples/BasicSample/TheoriesHaveTheirLimits.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScenarioTests;
+using Xunit;
+
+
+namespace BasicSample
+{
+    public partial class TheoriesHaveTheirLimits : IClassFixture<TheoriesHaveTheirLimits.ClassFixture>
+    {
+
+        public class ClassFixture
+        {
+            public int CurrentRepeatCount { get; set; }
+        }
+
+        readonly ClassFixture _classFixture;
+
+        public TheoriesHaveTheirLimits(ClassFixture classFixture)
+        {
+            _classFixture = classFixture;
+        }
+
+        [Scenario(TheoryTestCaseLimit = 5)]
+        public void Scenario(ScenarioContext scenario)
+        {
+            var currentRepeatCount = 0;
+
+            // 500 being an arbritrary limit that exceeds the configured 5 and default 100
+            for (var i = 0; i < 500; i++)
+            {
+                scenario.Theory("We can repeat this theory for all data entries", i, () =>
+                {
+                    Assert.Equal(0, currentRepeatCount);
+                    Assert.Equal(i, _classFixture.CurrentRepeatCount);
+
+                    currentRepeatCount += 1;
+                    _classFixture.CurrentRepeatCount += 1;
+                });
+            }
+
+            Assert.True(_classFixture.CurrentRepeatCount <= 5);
+        }
+    }
+}

--- a/src/ScenarioTests.Generator/ScenarioDescriptor.cs
+++ b/src/ScenarioTests.Generator/ScenarioDescriptor.cs
@@ -15,6 +15,7 @@ namespace ScenarioTests.Generator
 
         public string MethodName { get; set; }
         public bool IsAsync { get; set; }
+        public int? TheoryTestCaseLimit { get; set; }
 
         public List<ScenarioInvocationDescriptor> Invocations { get; set; }
     }

--- a/src/ScenarioTests.Generator/ScenarioInvocationDescriptor.cs
+++ b/src/ScenarioTests.Generator/ScenarioInvocationDescriptor.cs
@@ -10,7 +10,6 @@ namespace ScenarioTests.Generator
     {
         public string TestMethodName { get; set; }
         public string Name { get; set; }
-        public bool IsTheory { get; set; }
         public string FileName { get; set; }
         public int LineNumber { get; set; }
     }

--- a/src/ScenarioTests.Generator/ScenarioMethodInterpreter.cs
+++ b/src/ScenarioTests.Generator/ScenarioMethodInterpreter.cs
@@ -44,6 +44,13 @@ namespace ScenarioTests.Generator
                 .Cast<ScenarioTestMethodNamingPolicy>()
                 .FirstOrDefault();
 
+            var theoryTestCaseLimit = scenarioAttributeClass.NamedArguments
+                .Where(x => x.Key == "TheoryTestCaseLimit")
+                .Where(x => x.Value.Kind == TypedConstantKind.Primitive)
+                .Select(x => x.Value.Value)
+                .OfType<int?>()
+                .FirstOrDefault();
+
             if (methodSymbol.Parameters.Length != 1 || !SymbolEqualityComparer.Default.Equals(methodSymbol.Parameters[0].Type, scenarioContextTypeSymbol))
             {
                 var diagnostic = Diagnostic.Create(Diagnostics.RequiresSingleArgumentMethodError, methodDeclarationSyntax.GetLocation(), methodSymbol.Name);
@@ -94,7 +101,6 @@ namespace ScenarioTests.Generator
                     {
                         TestMethodName = testMethodName,
                         Name = factName,
-                        IsTheory = invocationSymbol.Name == "Theory",
                         FileName = methodDeclarationSyntax.SyntaxTree.FilePath,
                         LineNumber = invocationCandidate.GetLocation().GetMappedLineSpan().StartLinePosition.Line + 1
                     });
@@ -108,6 +114,7 @@ namespace ScenarioTests.Generator
                 ClassNamespace = methodSymbol.ContainingType.ContainingNamespace.IsGlobalNamespace ? null : methodSymbol.ContainingType.ContainingNamespace.ToDisplayString(),
                 MethodName = methodSymbol.Name,
                 IsAsync = !methodSymbol.ReturnsVoid && methodSymbol.ReturnType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, asynResultType)),
+                TheoryTestCaseLimit = theoryTestCaseLimit,
                 Invocations = invocations
             };
         }

--- a/src/ScenarioTests.Generator/TestMethodWriter.cs
+++ b/src/ScenarioTests.Generator/TestMethodWriter.cs
@@ -20,7 +20,8 @@ namespace ScenarioTests.Generator
 
         void WriteLine(string line)
         {
-            StringBuilder.AppendLine($"\t\t{line}");
+            StringBuilder.Append("\t\t");
+            StringBuilder.AppendLine(line);
         }
 
         public void Write(ScenarioDescriptor scenarioDescriptor, ScenarioInvocationDescriptor scenarioInvocationDescriptor)
@@ -31,9 +32,11 @@ namespace ScenarioTests.Generator
                 _ => $"{scenarioDescriptor.MethodName}_{scenarioInvocationDescriptor.Name}"
             };
 
+            var theoryAttributes = scenarioDescriptor.TheoryTestCaseLimit is not null ? $", TheoryTestCaseLimit = {scenarioDescriptor.TheoryTestCaseLimit}" : string.Empty;
+
             WriteLine("[global::System.Runtime.CompilerServices.CompilerGenerated]");
             WriteLine("[global::System.Diagnostics.DebuggerStepThrough]");
-            WriteLine($"[global::ScenarioTests.Internal.ScenarioFact(DisplayName = {Syntax.Literal(testMethodName)}, FactName = {Syntax.Literal(scenarioInvocationDescriptor.Name)}, FileName = {Syntax.Literal(scenarioInvocationDescriptor.FileName)}, LineNumber = {scenarioInvocationDescriptor.LineNumber}, IsTheory = {Syntax.LiteralExpression(scenarioInvocationDescriptor.IsTheory ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression)})]");
+            WriteLine($"[global::ScenarioTests.Internal.ScenarioFact(DisplayName = {Syntax.Literal(testMethodName)}, FactName = {Syntax.Literal(scenarioInvocationDescriptor.Name)}, FileName = {Syntax.Literal(scenarioInvocationDescriptor.FileName)}, LineNumber = {scenarioInvocationDescriptor.LineNumber}{theoryAttributes})]");
 
             if (scenarioDescriptor.IsAsync)
             {

--- a/src/ScenarioTests/Internal/ScenarioFactAttribute.cs
+++ b/src/ScenarioTests/Internal/ScenarioFactAttribute.cs
@@ -17,6 +17,6 @@ namespace ScenarioTests.Internal
         public string FactName { get; set; }
         public string FileName { get; set; }
         public int LineNumber { get; set; }
-        public bool IsTheory { get; set; }
+        public int TheoryTestCaseLimit { get; set; } = 100;
     }
 }

--- a/src/ScenarioTests/Internal/ScenarioFactTestCase.cs
+++ b/src/ScenarioTests/Internal/ScenarioFactTestCase.cs
@@ -14,24 +14,24 @@ namespace ScenarioTests.Internal
     sealed internal class ScenarioFactTestCase : XunitTestCase
     {
         string _factName;
-        bool _isTheory;
+        int _theoryTestCaseLimit;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         public ScenarioFactTestCase() { }
 
-        public ScenarioFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null, string factName = null, SourceInformation sourceInformation = null, bool isTheory = false) 
+        public ScenarioFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null, string factName = null, SourceInformation sourceInformation = null, int theoryTestCaseLimit = 100) 
             : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
         {
             _factName = factName;
-            _isTheory = isTheory;
+            _theoryTestCaseLimit = theoryTestCaseLimit;
             SourceInformation = sourceInformation;
         }
 
         public override void Serialize(IXunitSerializationInfo data)
         {
             data.AddValue("FactName", _factName);
-            data.AddValue("IsTheory", _isTheory);
+            data.AddValue("TheoryTestCaseLimits", _theoryTestCaseLimit);
 
             base.Serialize(data);
         }
@@ -39,12 +39,13 @@ namespace ScenarioTests.Internal
         public override void Deserialize(IXunitSerializationInfo data)
         {
             _factName = data.GetValue<string>("FactName");
-            _isTheory = data.GetValue<bool>("IsTheory");
+            _theoryTestCaseLimit = data.GetValue<int>("TheoryTestCaseLimits");
 
             base.Deserialize(data);
         }
 
         public string FactName => _factName;
+        public int TheoryTestCaseLimit => _theoryTestCaseLimit;
 
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource) 
             => new ScenarioFactTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync();

--- a/src/ScenarioTests/Internal/ScenarioFactTestCaseDiscoverer.cs
+++ b/src/ScenarioTests/Internal/ScenarioFactTestCaseDiscoverer.cs
@@ -33,7 +33,7 @@ namespace ScenarioTests.Internal
                 null,
                 factAttribute.GetNamedArgument<string>(nameof(ScenarioFactAttribute.FactName)),
                 sourceInformation, 
-                factAttribute.GetNamedArgument<bool>(nameof(ScenarioFactAttribute.IsTheory)));
+                factAttribute.GetNamedArgument<int>(nameof(ScenarioFactAttribute.TheoryTestCaseLimit)));
         }
     }
 }

--- a/src/ScenarioTests/ScenarioAttribute.cs
+++ b/src/ScenarioTests/ScenarioAttribute.cs
@@ -17,5 +17,10 @@ namespace ScenarioTests
         /// Get or set the naming policy for the generated test methods
         /// </summary>
         public ScenarioTestMethodNamingPolicy NamingPolicy { get; set; } = ScenarioTestMethodNamingPolicy.Test;
+
+        /// <summary>
+        /// Get or set an upper boundary of the max number of theory test cases that can be accepted.
+        /// </summary>
+        public int TheoryTestCaseLimit { get; set; }
     }
 }

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithAsyncFact.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithAsyncFact.verified.txt
@@ -4,7 +4,7 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5)]
 		public async System.Threading.Tasks.Task Scenario_T1(ScenarioTests.ScenarioContext scenarioContext)
 		{
 			await Scenario(scenarioContext).ConfigureAwait(false);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithComplexFactName.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithComplexFactName.verified.txt
@@ -4,7 +4,7 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_Name with a $!@$@!", FactName = "Name with a $!@$@!", FileName = "", LineNumber = 5, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_Name with a $!@$@!", FactName = "Name with a $!@$@!", FileName = "", LineNumber = 5)]
 		public void Scenario_Name_with_a_(global::ScenarioTests.ScenarioContext scenarioContext)
 		{
 			Scenario(scenarioContext);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithMixedFacts.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithMixedFacts.verified.txt
@@ -4,21 +4,21 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5)]
 		public async System.Threading.Tasks.Task Scenario_T1(ScenarioTests.ScenarioContext scenarioContext)
 		{
 			await Scenario(scenarioContext).ConfigureAwait(false);
 		}
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T2", FactName = "T2", FileName = "", LineNumber = 6, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T2", FactName = "T2", FileName = "", LineNumber = 6)]
 		public async System.Threading.Tasks.Task Scenario_T2(ScenarioTests.ScenarioContext scenarioContext)
 		{
 			await Scenario(scenarioContext).ConfigureAwait(false);
 		}
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T3", FactName = "T3", FileName = "", LineNumber = 7, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T3", FactName = "T3", FileName = "", LineNumber = 7)]
 		public async System.Threading.Tasks.Task Scenario_T3(ScenarioTests.ScenarioContext scenarioContext)
 		{
 			await Scenario(scenarioContext).ConfigureAwait(false);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithMultipleFacts.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithMultipleFacts.verified.txt
@@ -4,14 +4,14 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5)]
 		public void Scenario_T1(global::ScenarioTests.ScenarioContext scenarioContext)
 		{
 			Scenario(scenarioContext);
 		}
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T2", FactName = "T2", FileName = "", LineNumber = 6, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T2", FactName = "T2", FileName = "", LineNumber = 6)]
 		public void Scenario_T2(global::ScenarioTests.ScenarioContext scenarioContext)
 		{
 			Scenario(scenarioContext);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithSingleFact.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithSingleFact.verified.txt
@@ -4,7 +4,7 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5, IsTheory = false)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5)]
 		public void Scenario_T1(global::ScenarioTests.ScenarioContext scenarioContext)
 		{
 			Scenario(scenarioContext);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithSingleTheory.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithSingleTheory.verified.txt
@@ -4,7 +4,7 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5, IsTheory = true)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5)]
 		public void Scenario_T1(global::ScenarioTests.ScenarioContext scenarioContext)
 		{
 			Scenario(scenarioContext);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithTheoryTestCaseLimit.verified.txt
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.VerifyScenarioWithTheoryTestCaseLimit.verified.txt
@@ -4,7 +4,7 @@
     {
 		[global::System.Runtime.CompilerServices.CompilerGenerated]
 		[global::System.Diagnostics.DebuggerStepThrough]
-		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5)]
+		[global::ScenarioTests.Internal.ScenarioFact(DisplayName = "Scenario_T1", FactName = "T1", FileName = "", LineNumber = 5, TheoryTestCaseLimit = 5)]
 		public void Scenario_T1(global::ScenarioTests.ScenarioContext scenarioContext)
 		{
 			Scenario(scenarioContext);

--- a/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.cs
+++ b/tests/ScenarioTests.Generator.Tests/ScenarioTestGeneratorTests.cs
@@ -245,6 +245,27 @@ public partial class C {
             return Verifier.Verify(result.GeneratedTrees[0].ToString());
         }
 
+        [Fact]
+        public Task VerifyScenarioWithTheoryTestCaseLimit()
+        {
+            var compilation = CreateCompilation(@"
+public partial class C {
+    [ScenarioTests.Scenario(TheoryTestCaseLimit = 5)]
+    public void Scenario(ScenarioTests.ScenarioContext s) {
+        s.Theory(""T1"", 1, () => { 
+        });
+    }
+}
+");
+
+            var result = RunGenerator(compilation);
+
+            Assert.Empty(result.Diagnostics);
+            Assert.Single(result.GeneratedTrees);
+
+            return Verifier.Verify(result.GeneratedTrees[0].ToString());
+        }
+
         #region Helpers
 
         Compilation CreateCompilation(string source, bool expectedToCompile = true)

--- a/tests/ScenarioTests.Tests/IntegrationTests.cs
+++ b/tests/ScenarioTests.Tests/IntegrationTests.cs
@@ -19,8 +19,24 @@ namespace ScenarioTests.Tests
         }
 
 
-        [Internal.ScenarioFact(DisplayName = nameof(SimpleTheory), FactName = "X", IsTheory = true)]
+        [Internal.ScenarioFact(DisplayName = nameof(SimpleTheory), FactName = "X")]
         public void SimpleTheory(ScenarioContext scenarioContext)
+        {
+            var invocations = 0;
+
+            for (var repeat = 0; repeat < 5; repeat++)
+            {
+                scenarioContext.Theory("X", repeat, () =>
+                {
+                    Assert.Equal(0, invocations++);
+                });
+            }
+
+            Assert.Equal(1, invocations);
+        }
+
+        [Internal.ScenarioFact(DisplayName = nameof(SimpleTheory), FactName = "X")]
+        public void SimpleTheory2(ScenarioContext scenarioContext)
         {
             var invocations = 0;
 

--- a/tests/ScenarioTests.Tests/ScenarioContextTests.cs
+++ b/tests/ScenarioTests.Tests/ScenarioContextTests.cs
@@ -158,5 +158,22 @@ namespace ScenarioTests.Tests
 
             Assert.True(invoked);
         }
+
+        [Fact]
+        public void Theory_MultipleDataRows_InvokesAll()
+        {
+            var context = new ScenarioContext("X", (_, i) => i());
+
+            var invoked = 0;
+            for (var i = 0; i < 5; i++)
+            {
+                context.Theory("X", i, () =>
+                {
+                    invoked++;
+                });
+            }
+
+            Assert.Equal(5, invoked);
+        }
     }
 }


### PR DESCRIPTION
Before, whenever theory test cases exceeded their hardcoded limit of 500 cases, subsequent cases would not run and no message would be generated informing the user that a limit had been reached.

In this PR:
- A default limit is configured with up to 100 cases.  
- A custom limit can be configured on the Scenario attribute.
- Whenever a limit is reached, one additional skipped test case will  be generated to inform the user of the limit