### PR TITLE
Updated Roslyn analyzer nugets to support building in VS2022

### DIFF
--- a/src/ScenarioTests.Generator/Diagnostics.cs
+++ b/src/ScenarioTests.Generator/Diagnostics.cs
@@ -12,7 +12,7 @@ namespace ScenarioTests.Generator
         public static readonly DiagnosticDescriptor RequiresSingleArgumentMethodError = new(
             id: "ST0001",
             title: "Scenario should accept a single argument of type ScenarioContext",
-            messageFormat: "Scenario '{0}' should accept a single argument of type ScenarioContext.",
+            messageFormat: "Scenario '{0}' should accept a single argument of type ScenarioContext",
             category: "Design",
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);

--- a/src/ScenarioTests.Generator/ScenarioTests.Generator.csproj
+++ b/src/ScenarioTests.Generator/ScenarioTests.Generator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);nullable;NU5128</NoWarn>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +13,6 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22518.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently this will not build in VS2022 because of this issue https://github.com/dotnet/roslyn-analyzers/issues/5890.

There are two options to fix this, either avoid using the `new()` type constructors for diagnostics or update the Roslyn analyzer package to the latest.  I am open to doing either.  Was hoping to work on a feature enhancement after I get this building correctly in VS2022.

The edits to the files outside of the nuget updates was because of complaints from the new analyzers in the Roslyn package.